### PR TITLE
Performance tests and performance boost

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
+require 'tasks/performance'
 
 RSpec::Core::RakeTask.new do |t|
   t.rspec_opts = ["-c", "-f progress"]

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'tasks/performance'
+require File.expand_path(File.join(File.dirname(__FILE__), 'tasks/performance'))
 
 RSpec::Core::RakeTask.new do |t|
   t.rspec_opts = ["-c", "-f progress"]

--- a/lib/socky/server.rb
+++ b/lib/socky/server.rb
@@ -10,14 +10,15 @@ module Socky
   module Server
     ROOT = File.expand_path(File.dirname(__FILE__))
   
-    autoload :Application, "#{ROOT}/server/application"
-    autoload :Channel,     "#{ROOT}/server/channel"
-    autoload :Config,      "#{ROOT}/server/config"
-    autoload :Connection,  "#{ROOT}/server/connection"
-    autoload :HTTP,        "#{ROOT}/server/http"
-    autoload :Logger,      "#{ROOT}/server/logger"
-    autoload :Message,     "#{ROOT}/server/message"
-    autoload :Misc,        "#{ROOT}/server/misc"
-    autoload :WebSocket,   "#{ROOT}/server/websocket"
+    autoload :Application,     "#{ROOT}/server/application"
+    autoload :Channel,         "#{ROOT}/server/channel"
+    autoload :Config,          "#{ROOT}/server/config"
+    autoload :Connection,      "#{ROOT}/server/connection"
+    autoload :HTTP,            "#{ROOT}/server/http"
+    autoload :Logger,          "#{ROOT}/server/logger"
+    autoload :Message,         "#{ROOT}/server/message"
+    autoload :Misc,            "#{ROOT}/server/misc"
+    autoload :WebSocket,       "#{ROOT}/server/websocket"
+    autoload :CachedJsonHash,  "#{ROOT}/server/cached_json_hash"
   end
 end

--- a/lib/socky/server/cached_json_hash.rb
+++ b/lib/socky/server/cached_json_hash.rb
@@ -1,10 +1,13 @@
 module Socky
   module Server
     class CachedJsonHash < Hash
-      include Misc
 
       def to_json
         @json ||= super
+      end
+
+      def remove_cache
+        @json = nil
       end
 
     end

--- a/lib/socky/server/cached_json_hash.rb
+++ b/lib/socky/server/cached_json_hash.rb
@@ -1,0 +1,13 @@
+module Socky
+  module Server
+    class CachedJsonHash < Hash
+      include Misc
+
+      def to_json
+        @json ||= super
+      end
+
+    end
+  end
+end
+

--- a/lib/socky/server/channel/base.rb
+++ b/lib/socky/server/channel/base.rb
@@ -34,8 +34,9 @@ module Socky
         end
         
         def send_data(data, except = nil)
+          cached_json_data = CachedJsonHash[data]
           self.subscribers.each do |subscriber_id, subscriber|
-            subscriber['connection'].send_data(data) unless subscriber_id == except || !subscriber['read']
+            subscriber['connection'].send_data(cached_json_data) unless subscriber_id == except || !subscriber['read']
           end
         end
         
@@ -51,7 +52,7 @@ module Socky
         
         def deliver(connection, message)
           return unless connection.nil? || (subscribers[connection.id] && subscribers[connection.id]['write'])
-          send_data(CachedJsonHash['event' => message.event, 'channel' => self.name, 'data' => message.user_data ])
+          send_data('event' => message.event, 'channel' => self.name, 'data' => message.user_data)
         end
         
         protected

--- a/lib/socky/server/channel/base.rb
+++ b/lib/socky/server/channel/base.rb
@@ -51,7 +51,7 @@ module Socky
         
         def deliver(connection, message)
           return unless connection.nil? || (subscribers[connection.id] && subscribers[connection.id]['write'])
-          send_data({ 'event' => message.event, 'channel' => self.name, 'data' => message.user_data })
+          send_data(CachedJsonHash['event' => message.event, 'channel' => self.name, 'data' => message.user_data ])
         end
         
         protected

--- a/spec/performance/connectin_performance.rb
+++ b/spec/performance/connectin_performance.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'performance_helper'
+require 'benchmark'
+
+describe 'Connecting Performance' do
+
+  it "For x listeners" do
+    [1, 10, 100].each do |count|
+      results = []
+      5.times do
+        @application = Socky::Server::Application.new('test_application', 'test_secret')
+        @channel = "presence"
+        results << Benchmark.realtime {count.times { add_listener }}
+        clean_application
+      end
+      print_result count, results
+    end
+  end
+
+end
+
+
+
+
+
+

--- a/spec/performance/send_many_messages_performance.rb
+++ b/spec/performance/send_many_messages_performance.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'performance_helper'
+require 'benchmark'
+
+describe 'Sending Many Messages Performance' do
+
+  it "For 1 listener and x messages" do
+    [1, 10, 100].each do |count|
+      results = []
+      5.times do
+        @application = application_with_listeners(1)
+        results << Benchmark.realtime {send_messages(count)}
+        clean_application
+      end
+      print_result count, results
+    end
+  end
+
+end
+
+
+
+
+

--- a/spec/performance/send_many_messages_performance.rb
+++ b/spec/performance/send_many_messages_performance.rb
@@ -8,6 +8,7 @@ describe 'Sending Many Messages Performance' do
     [1, 10, 100].each do |count|
       results = []
       5.times do
+        @channel = "private"
         @application = application_with_listeners(1)
         results << Benchmark.realtime {send_messages(count)}
         clean_application

--- a/spec/performance/send_message_to_many_listeners_performance.rb
+++ b/spec/performance/send_message_to_many_listeners_performance.rb
@@ -8,6 +8,7 @@ describe 'Sending Message To Many Listeners Performance' do
     [1, 10, 100].each do |count|
       results = []
       5.times do 
+        @channel = "private"
         @application = application_with_listeners(count)
         results << Benchmark.realtime {send_messages(1)}
         clean_application

--- a/spec/performance/send_message_to_many_listeners_performance.rb
+++ b/spec/performance/send_message_to_many_listeners_performance.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'performance_helper'
+require 'benchmark'
+
+describe 'Sending Message To Many Listeners Performance' do
+
+  it "For x listeners and 1 message" do
+    [1, 10, 100].each do |count|
+      results = []
+      5.times do 
+        @application = application_with_listeners(count)
+        results << Benchmark.realtime {send_messages(1)}
+        clean_application
+      end
+      print_result count, results
+    end
+  end
+end
+
+
+
+
+
+

--- a/spec/performance_helper.rb
+++ b/spec/performance_helper.rb
@@ -19,7 +19,7 @@ def add_listener
   websocket = mock_websocket(@application.name)
   env = { 'PATH_INFO' => '/websocket/' + @application.name }
   websocket.on_open(env)
-  data = {'event' => 'socky:subscribe', 'channel' => 'private-channel', 'auth' => 'test_auth'}
+  data = {'event' => 'socky:subscribe', 'channel' => "#{@channel}-channel", 'auth' => 'test_auth'}
   websocket.on_message(env, data)
   websocket
 end
@@ -28,19 +28,20 @@ def add_writer
   @writer_ws = mock_websocket(@application.name)
   env = { 'PATH_INFO' => '/websocket/' + @application.name }
   @writer_ws.on_open(env)
-  data = {'event' => 'socky:subscribe', 'channel' => 'private-channel', 'write' => 'true', 'auth' => 'test_auth'}
+  data = {'event' => 'socky:subscribe', 'channel' => "#{@channel}-channel", 'write' => 'true', 'auth' => 'test_auth'}
   @writer_ws.on_message(env, data)
   @writer_ws
 end
 
 def send_messages count
   env = { 'PATH_INFO' => '/websocket/' + @application.name }
-  data = {'event' => 'send', 'channel' => 'private-channel', 'user_data' => "test_message"}
+  data = {'event' => 'send', 'channel' => "#{@channel}-channel", 'user_data' => "test_message"}
   count.times { @writer_ws.on_message(env, data) }
 end
 
 def clean_application
   @application.connections.values.each {|c| c.destroy}
+  Socky::Server::Channel::Private.list['test_application'] = Hash.new
   Socky::Server::Channel::Private.list['test_application'] = Hash.new
   Socky::Server::Application.list.delete('test_application') 
 end

--- a/spec/performance_helper.rb
+++ b/spec/performance_helper.rb
@@ -1,0 +1,54 @@
+Socky::Server::Channel::Private.class_eval do
+  protected
+
+  def check_auth(connection, message)
+    true
+  end
+
+end
+
+
+def application_with_listeners count
+  @application = Socky::Server::Application.new('test_application', 'test_secret')
+  count.times { add_listener }
+  add_writer
+  @application
+end
+
+def add_listener
+  websocket = mock_websocket(@application.name)
+  env = { 'PATH_INFO' => '/websocket/' + @application.name }
+  websocket.on_open(env)
+  data = {'event' => 'socky:subscribe', 'channel' => 'private-channel', 'auth' => 'test_auth'}
+  websocket.on_message(env, data)
+  websocket
+end
+
+def add_writer
+  @writer_ws = mock_websocket(@application.name)
+  env = { 'PATH_INFO' => '/websocket/' + @application.name }
+  @writer_ws.on_open(env)
+  data = {'event' => 'socky:subscribe', 'channel' => 'private-channel', 'write' => 'true', 'auth' => 'test_auth'}
+  @writer_ws.on_message(env, data)
+  @writer_ws
+end
+
+def send_messages count
+  env = { 'PATH_INFO' => '/websocket/' + @application.name }
+  data = {'event' => 'send', 'channel' => 'private-channel', 'user_data' => "test_message"}
+  count.times { @writer_ws.on_message(env, data) }
+end
+
+def clean_application
+  @application.connections.values.each {|c| c.destroy}
+  Socky::Server::Channel::Private.list['test_application'] = Hash.new
+  Socky::Server::Application.list.delete('test_application') 
+end
+
+
+def print_result label, results
+  avg = results.inject(0.0) { |sum, el| sum + el } / results.size
+  puts ["#{label}:".ljust(15), avg].join
+end
+
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,13 +8,16 @@ def mock_websocket(application)
   env = {}
   env['PATH_INFO'] = '/websocket/' + application
   connection = Socky::Server::WebSocket.new.call(env)
-  connection.stub!(:send_data)
+  send_data_method = connection.method(:send_data)
+  connection.stub!(:send_data).and_return do |*args|
+    a = send_data_method.call(*args)
+  end
   connection
 end
 
 def mock_connection(application)
   websocket = mock_websocket(application)
-  
+
   env = { 'PATH_INFO' => '/websocket/' + application }
   websocket.on_open(env)
 end

--- a/tasks/performance.rb
+++ b/tasks/performance.rb
@@ -1,0 +1,11 @@
+require 'rspec/core'
+require 'rspec/core/rake_task'
+
+namespace :spec do
+  desc "Run the performance tests"
+  RSpec::Core::RakeTask.new("performance") do |t|
+    t.pattern = "./spec/**/*_performance.rb"
+    t.rspec_opts = ["-c", "-f documentation"]
+  end
+end
+


### PR DESCRIPTION
I wrote some performance tests for sending messages by socky-server. You can run it by "rake spec:performance". Also made json optimalization. Now there is only one json encoding per message. Before there was x calls to_json method on hash where x is the number of channel listeners. Here is some output before change and after change on ruby 1.8.7 and 1.9.2.

Send 1 message to 100 listeners
PRE     1.8.7 - 0.0117639541625977
AFTER 1.8.7 - 0.00345268249511719

PRE     1.9.2 - 0.0024651527404785157
AFTER 1.9.2 - 0.0016480445861816405
